### PR TITLE
Fix: Exception when printing models with Unicode characters #36

### DIFF
--- a/examples/response/binary_search.py
+++ b/examples/response/binary_search.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
 import sys
+import codecs
 from cbapi.response.models import Binary
 from cbapi.example_helpers import build_cli_parser, get_cb_response_object
 
+sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 def main():
     parser = build_cli_parser()


### PR DESCRIPTION
Used codecs to fix issue with printing of characters such as below:
## AB8B7D5E808226F8E4279F6A779DCF2D

Size (bytes)         : 878784
Signature Status     : True
Traceback (most recent call last):
  File "C:\Users\jscarpaci\PycharmProjects\untitled\binary_search.py", line 38,
in <module>
    sys.exit(main())
  File "C:\Users\jscarpaci\PycharmProjects\untitled\binary_search.py", line 26,
in main
    print("%-20s : %s" % ('Product Name', binary.product_name))
  File "C:\Python27\lib\encodings\cp437.py", line 12, in encode
    return codecs.charmap_encode(input,errors,encoding_map)
UnicodeEncodeError: 'charmap' codec can't encode character u'\xae' in position 2
8: character maps to <undefined>
